### PR TITLE
Added .NET7 support to sample devfile

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # dotnet-web-simple application
 
-It is a simple dotnet web application which uses `netcoreapp3.1` as a target framework.
+It is a simple dotnet web application which uses `netcoreapp7.0` as a target framework.
 
  
 # Application Output

--- a/web.csproj
+++ b/web.csproj
@@ -7,7 +7,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp7.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 


### PR DESCRIPTION
Added Dotnet7 support to the sample project by modifying `Target Framework` from the `web.csproj` file.
The earlier 3.1 version was causing a failure on running the `dotnet run` command.
```
dotnet-web-simple (devspaces-3-rhel-8) $ dotnet run
/usr/lib64/dotnet/sdk/7.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(135,5): error NETSDK1084: There is no application host available for the specified RuntimeIdentifier 'rhel.8-ppc64le'. [/projects/dotnet-web-simple/web.csproj]
```

On modification, the dotnet sample application is running successfully.