### PR TITLE
chore: use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -13,7 +13,7 @@ components:
       endpoints:
         - exposure: public
           name: 'hello-endpoint'
-          protocol: http
+          protocol: https
           targetPort: 5032
       volumeMounts:
         - name: nuget


### PR DESCRIPTION
use https protocol in endpoint

![screenshot-devspaces apps sandbox-m4 g2pi p1 openshiftapps com-2023 12 21-14_45_41](https://github.com/devspaces-samples/dotnet-web-simple/assets/1271546/7fff3794-9c26-41b2-b496-c06f1a962c84)

Related issue: https://issues.redhat.com/browse/CRW-5377