### PR TITLE
set devfile's schemaVersion to 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: dotnet
 components:


### PR DESCRIPTION
Updates devfile's schemaVersion to 2.2.2

Related issue: https://github.com/eclipse/che/issues/21985


![screenshot-devspaces apps sandbox-stage gb17 p1 openshiftapps com-2024 02 01-16_14_47](https://github.com/devspaces-samples/dotnet-web-simple/assets/1271546/1650704b-88e4-44dc-9a5e-6a2545f62b93)




