### PR TITLE
feat: Use community image for tools container

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,41 @@
+name: Build and Push Container Image
+
+on:
+  push:
+    paths:
+      - 'workspace-container-image/Containerfile'
+      - 'workspace-container-image/entrypoint.sh'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Generate tag
+        id: tag
+        run: echo "tag=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_OUTPUT
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./workspace-container-image
+          file: ./workspace-container-image/Containerfile
+          push: true
+          tags: quay.io/devspaces/dotnet-90:9.0-fedora-${{ steps.tag.outputs.tag }}
+          platforms: linux/amd64,linux/ppc64le,linux/s390x

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/net8.0/web.dll",
+            "program": "${workspaceFolder}/bin/Debug/net9.0/web.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": true,

--- a/Readme.md
+++ b/Readme.md
@@ -10,4 +10,4 @@ The app will print `Hello World!`
 
 ## Image Of Devfile
 
-[Community .NET Image](quay.io/cgruver0/che/dot-net:fedora) is used as an image for .NET development and it's defined in https://github.com/cgruver/dev-spaces-dotnet/blob/main/workspace-container-image/Containerfile.
+[Community .NET Image](quay.io/devspaces/dotnet-90) is used as an image for .NET development and it's defined in https://github.com/devspaces-samples/dotnet-web-simple/blob/devspaces-3-rhel-9/workspace-container-image/Containerfile.

--- a/Readme.md
+++ b/Readme.md
@@ -6,3 +6,8 @@ It is a simple dotnet web application which uses `net8.0` as a target framework.
 # Application Output
 
 The app will print `Hello World!`
+
+
+## Image Of Devfile
+
+[Community .NET Image](quay.io/cgruver0/che/dot-net:fedora) is used as an image for .NET development and it's defined in https://github.com/cgruver/dev-spaces-dotnet/blob/main/workspace-container-image/Containerfile.

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,8 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/cgruver0/che/dot-net:fedora
+      #  quay.io/devspaces/dotnet-90:9.0-fedora-20250415-095811
+      image: quay.io/devspaces/dotnet-90@sha256:5cb201f58ebf20d76b7b99e013da46aa6cfe594c5763ab873bcc6436965d7859
       memoryLimit: '2Gi'
       memoryRequest: '1Gi'
       cpuLimit: '1'

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: registry.redhat.io/devspaces/udi-rhel9:3.21
+      image: quay.io/cgruver0/che/dot-net:fedora
       memoryLimit: '2Gi'
       memoryRequest: '1Gi'
       cpuLimit: '1'

--- a/web.csproj
+++ b/web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/workspace-container-image/Containerfile
+++ b/workspace-container-image/Containerfile
@@ -1,0 +1,39 @@
+FROM quay.io/fedora/fedora:41
+
+ARG USER_HOME_DIR="/home/user"
+ARG WORK_DIR="/projects"
+ARG INSTALL_PACKAGES="procps-ng openssl git tar gzip zip xz unzip which shadow-utils bash zsh vi wget jq podman buildah skopeo podman-docker glibc-devel zlib-devel gcc libffi-devel libstdc++-devel gcc-c++ glibc-langpack-en ca-certificates python3-pip python3-devel fuse-overlayfs util-linux vim-minimal vim-enhanced dotnet-hostfxr-9.0 dotnet-runtime-9.0 dotnet-sdk-9.0"
+
+ENV HOME=${USER_HOME_DIR}
+ENV BUILDAH_ISOLATION=chroot
+
+COPY --chown=0:0 entrypoint.sh /
+
+RUN microdnf --disableplugin=subscription-manager install -y ${INSTALL_PACKAGES}; \
+  microdnf update -y ; \
+  microdnf clean all ; \
+  mkdir -p /usr/local/bin ; \
+  mkdir -p ${WORK_DIR} ; \
+  pip3 install -U podman-compose ; \
+  pip3 install -U cekit ; \
+  chgrp -R 0 /home ; \
+  chmod -R g=u /home ${WORK_DIR} ; \
+  chmod +x /entrypoint.sh ; \
+  chown 0:0 /etc/passwd ; \
+  chown 0:0 /etc/group ; \
+  chmod g=u /etc/passwd /etc/group ; \
+  # Setup for rootless podman
+  setcap cap_setuid+ep /usr/bin/newuidmap ; \
+  setcap cap_setgid+ep /usr/bin/newgidmap ; \
+  touch /etc/subgid /etc/subuid ; \
+  chown 0:0 /etc/subgid ; \
+  chown 0:0 /etc/subuid ; \
+  chmod -R g=u /etc/subuid /etc/subgid ; \
+  # Create Sym Links for OpenShift CLI (Assumed to be retrieved by an init-container)
+  ln -s /projects/bin/oc /usr/local/bin/oc ; \
+  ln -s /projects/bin/kubectl /usr/local/bin/kubectl
+
+USER 1000
+WORKDIR ${WORK_DIR}
+ENTRYPOINT ["/usr/libexec/podman/catatonit","--","/entrypoint.sh"]
+CMD [ "tail", "-f", "/dev/null" ]

--- a/workspace-container-image/entrypoint.sh
+++ b/workspace-container-image/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Create Home directory
+if [ ! -d "${HOME}" ]
+then
+  mkdir -p "${HOME}"
+fi
+
+# Configure Podman builds to use vfs or fuse-overlayfs
+if [ ! -d "${HOME}/.config/containers" ]; then
+  mkdir -p ${HOME}/.config/containers
+  if [ -c "/dev/fuse" ] && [ -f "/usr/bin/fuse-overlayfs" ]; then
+    (echo '[storage]';echo 'driver = "overlay"';echo '[storage.options.overlay]';echo 'mount_program = "/usr/bin/fuse-overlayfs"') > ${HOME}/.config/containers/storage.conf
+  else
+    (echo '[storage]';echo 'driver = "vfs"') > "${HOME}"/.config/containers/storage.conf
+  fi
+fi
+
+# Create User ID
+if ! whoami &> /dev/null
+then
+  if [ -w /etc/passwd ]
+  then
+    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+    echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
+  fi
+fi
+
+# Create subuid/gid entries for the user
+USER=$(whoami)
+START_ID=$(( $(id -u)+1 ))
+echo "${USER}:${START_ID}:2147483646" > /etc/subuid
+echo "${USER}:${START_ID}:2147483646" > /etc/subgid
+
+# Configure Z shell
+if [ ! -f ${HOME}/.zshrc ]
+then
+  (echo "HISTFILE=${HOME}/.zsh_history"; echo "HISTSIZE=1000"; echo "SAVEHIST=1000") > ${HOME}/.zshrc
+  (echo "if [ -f ${PROJECT_SOURCE}/workspace.rc ]"; echo "then"; echo "  . ${PROJECT_SOURCE}/workspace.rc"; echo "fi") >> ${HOME}/.zshrc
+fi
+
+# Login to the local image registry
+podman login -u $(oc whoami) -p $(oc whoami -t)  image-registry.openshift-image-registry.svc:5000
+
+exec "$@"


### PR DESCRIPTION
- Add Containerfile that is based on Fedora image
- Add GH action to build and push image
- Use quay.io/devspaces/dotnet-90 image for tools container
![screenshot-orch_psi_redhat_com-2025_04_14-15_40_14](https://github.com/user-attachments/assets/99856a8d-d6dc-4f8f-a1da-2ce02ba547df)

**IMPORTANT:** The workspace won't start on AirGap DevSpaces instance if quay.io/devspaces/dotnet-90@sha256:5cb201f58ebf20d76b7b99e013da46aa6cfe594c5763ab873bcc6436965d7859 image is not mirrored in OS cluster.

To test:

[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://github.com/devspaces-samples/dotnet-web-simple/tree/sv-community)

